### PR TITLE
Enhance support of a parameter that can start with the name of another one

### DIFF
--- a/src/main/xquery/xqdoc2openapi-lib.xqm
+++ b/src/main/xquery/xqdoc2openapi-lib.xqm
@@ -32,7 +32,7 @@ as xs:string
 declare function xqdoc2openapi:get-string-parameter-description($function as node(), $param-name as xs:string)
 as xs:string
 {
-  let $param := $function/xqdoc:comment/xqdoc:param[fn:starts-with(., $param-name)]/text()
+  let $param := $function/xqdoc:comment/xqdoc:param[.=$param-name]/text()
 
   return
     if ($param)


### PR DESCRIPTION
or at least try to fix the case where next substring-after call get multiples params as first  a single string value param...